### PR TITLE
Fix situation remain CLOSE_WAIT socket in handler socket timeout

### DIFF
--- a/lib/node-handlersocket.js
+++ b/lib/node-handlersocket.js
@@ -172,6 +172,7 @@ Connection.prototype._emitClose = function _emitClose(error) {
   }
   this._notifyError(error);
   this.emit('close');
+  this.close();
   this._socket = null;
 };
 


### PR DESCRIPTION
If not issue command using handlersocket during loose_handlersocket_timeout ( in mysqld setting ), emit 'end' event.

But don't invoke net.socket.close() in nodejs api, this socket is not released.
( Refer to : https://nodejs.org/api/net.html#net_event_end )

